### PR TITLE
excrypto: Add SSL 2.0

### DIFF
--- a/crypto/ssl2/alert.go
+++ b/crypto/ssl2/alert.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import "fmt"
+
+// ErrorCode is the 2-octet error value carried in an SSL 2.0 ERROR
+// message (handshake message type 0). Reference: "The SSL Protocol" §1.5.1.
+type ErrorCode uint16
+
+const (
+	ErrNoCipher        ErrorCode = 0x0001
+	ErrNoCertificate   ErrorCode = 0x0002
+	ErrBadCertificate  ErrorCode = 0x0004
+	ErrUnsupportedCert ErrorCode = 0x0006
+)
+
+// String returns the canonical SSL 2.0 error name.
+func (e ErrorCode) String() string {
+	switch e {
+	case ErrNoCipher:
+		return "NO-CIPHER-ERROR"
+	case ErrNoCertificate:
+		return "NO-CERTIFICATE-ERROR"
+	case ErrBadCertificate:
+		return "BAD-CERTIFICATE-ERROR"
+	case ErrUnsupportedCert:
+		return "UNSUPPORTED-CERTIFICATE-TYPE-ERROR"
+	}
+	return fmt.Sprintf("UNKNOWN-ERROR(0x%04x)", uint16(e))
+}
+
+// Error implements the error interface so an [ErrorCode] returned from a
+// peer can be propagated directly.
+func (e ErrorCode) Error() string {
+	return "ssl2: peer sent " + e.String()
+}

--- a/crypto/ssl2/cipher.go
+++ b/crypto/ssl2/cipher.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+// Version is the on-the-wire SSL 2.0 protocol version.
+//
+// Some implementations (notably servers that "downgrade" to SSL 2.0 from a
+// higher request) will echo back exactly the version offered. We accept any
+// version whose major byte is 0x00 in [ParseServerHello]; callers that want
+// to be strict can compare against [Version].
+const Version uint16 = 0x0002
+
+// MessageType identifies an SSL 2.0 handshake message.
+//
+// Reference: Hickman, "The SSL Protocol", §1.4 ("SSL Record Header Format")
+// and §1.5 ("SSL Handshake Protocol").
+type MessageType uint8
+
+const (
+	MsgError              MessageType = 0
+	MsgClientHello        MessageType = 1
+	MsgClientMasterKey    MessageType = 2
+	MsgClientFinished     MessageType = 3
+	MsgServerHello        MessageType = 4
+	MsgServerVerify       MessageType = 5
+	MsgServerFinished     MessageType = 6
+	MsgRequestCertificate MessageType = 7
+	MsgClientCertificate  MessageType = 8
+)
+
+// String returns the canonical SSL 2.0 message name.
+func (m MessageType) String() string {
+	switch m {
+	case MsgError:
+		return "ERROR"
+	case MsgClientHello:
+		return "CLIENT-HELLO"
+	case MsgClientMasterKey:
+		return "CLIENT-MASTER-KEY"
+	case MsgClientFinished:
+		return "CLIENT-FINISHED"
+	case MsgServerHello:
+		return "SERVER-HELLO"
+	case MsgServerVerify:
+		return "SERVER-VERIFY"
+	case MsgServerFinished:
+		return "SERVER-FINISHED"
+	case MsgRequestCertificate:
+		return "REQUEST-CERTIFICATE"
+	case MsgClientCertificate:
+		return "CLIENT-CERTIFICATE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// CertType identifies the certificate format carried in SERVER-HELLO and
+// CLIENT-CERTIFICATE messages. SSL 2.0 only ever defined one value (X.509),
+// but some implementations have been observed to send 0 when no certificate
+// is available.
+type CertType uint8
+
+const (
+	CertTypeNone CertType = 0
+	CertTypeX509 CertType = 1
+)
+
+// CipherKind is a 3-octet SSL 2.0 cipher specification (often called a
+// "CIPHER-KIND" in the Netscape draft). The high octet identifies the
+// algorithm family; the low two octets carry the effective key size in bits
+// encoded big-endian.
+//
+// Note that the SSL 3.0 / TLS 1.0+ cipher numbering is two octets and is
+// disjoint from this 3-octet space. Do not confuse the two.
+type CipherKind uint32
+
+// The original Netscape draft defined seven cipher kinds. Values are taken
+// from §C.4 of "The SSL Protocol".
+const (
+	CK_RC4_128_WITH_MD5              CipherKind = 0x010080
+	CK_RC4_128_EXPORT40_WITH_MD5     CipherKind = 0x020080
+	CK_RC2_128_CBC_WITH_MD5          CipherKind = 0x030080
+	CK_RC2_128_CBC_EXPORT40_WITH_MD5 CipherKind = 0x040080
+	CK_IDEA_128_CBC_WITH_MD5         CipherKind = 0x050080
+	CK_DES_64_CBC_WITH_MD5           CipherKind = 0x060040
+	CK_DES_192_EDE3_CBC_WITH_MD5     CipherKind = 0x0700C0
+)
+
+// AllKnownCipherKinds returns every CipherKind defined by the SSL 2.0 draft,
+// in the canonical advertisement order used by historical clients (strongest
+// first). Useful for [BuildClientHello] when probing.
+func AllKnownCipherKinds() []CipherKind {
+	return []CipherKind{
+		CK_DES_192_EDE3_CBC_WITH_MD5,
+		CK_RC4_128_WITH_MD5,
+		CK_RC2_128_CBC_WITH_MD5,
+		CK_IDEA_128_CBC_WITH_MD5,
+		CK_DES_64_CBC_WITH_MD5,
+		CK_RC4_128_EXPORT40_WITH_MD5,
+		CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+	}
+}
+
+// Name returns the canonical SSL 2.0 cipher-spec name (e.g. "SSL_CK_RC4_128_WITH_MD5")
+// or "SSL_CK_UNKNOWN(0xXXXXXX)" if the value is not one of the seven defined
+// kinds.
+func (c CipherKind) Name() string {
+	switch c {
+	case CK_RC4_128_WITH_MD5:
+		return "SSL_CK_RC4_128_WITH_MD5"
+	case CK_RC4_128_EXPORT40_WITH_MD5:
+		return "SSL_CK_RC4_128_EXPORT40_WITH_MD5"
+	case CK_RC2_128_CBC_WITH_MD5:
+		return "SSL_CK_RC2_128_CBC_WITH_MD5"
+	case CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+		return "SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5"
+	case CK_IDEA_128_CBC_WITH_MD5:
+		return "SSL_CK_IDEA_128_CBC_WITH_MD5"
+	case CK_DES_64_CBC_WITH_MD5:
+		return "SSL_CK_DES_64_CBC_WITH_MD5"
+	case CK_DES_192_EDE3_CBC_WITH_MD5:
+		return "SSL_CK_DES_192_EDE3_CBC_WITH_MD5"
+	}
+	return "SSL_CK_UNKNOWN"
+}
+
+// EffectiveKeyBits returns the number of secret key bits used by this cipher
+// (i.e. the bits the client must keep secret in CLIENT-MASTER-KEY). For
+// "export" ciphers this is 40, even though the total key length is 128 bits.
+func (c CipherKind) EffectiveKeyBits() int {
+	return int(c & 0xFFFF)
+}
+
+// IsExport reports whether this cipher is a 40-bit US-export-grade cipher.
+func (c CipherKind) IsExport() bool {
+	switch c {
+	case CK_RC4_128_EXPORT40_WITH_MD5, CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+		return true
+	}
+	return false
+}

--- a/crypto/ssl2/cipher_test.go
+++ b/crypto/ssl2/cipher_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import "testing"
+
+func TestMessageTypeString(t *testing.T) {
+	cases := map[MessageType]string{
+		MsgError:              "ERROR",
+		MsgClientHello:        "CLIENT-HELLO",
+		MsgClientMasterKey:    "CLIENT-MASTER-KEY",
+		MsgClientFinished:     "CLIENT-FINISHED",
+		MsgServerHello:        "SERVER-HELLO",
+		MsgServerVerify:       "SERVER-VERIFY",
+		MsgServerFinished:     "SERVER-FINISHED",
+		MsgRequestCertificate: "REQUEST-CERTIFICATE",
+		MsgClientCertificate:  "CLIENT-CERTIFICATE",
+		MessageType(99):       "UNKNOWN",
+	}
+	for m, want := range cases {
+		if got := m.String(); got != want {
+			t.Errorf("MessageType(%d).String() = %q, want %q", m, got, want)
+		}
+	}
+}
+
+func TestCipherKindNames(t *testing.T) {
+	cases := []struct {
+		kind   CipherKind
+		name   string
+		bits   int
+		export bool
+	}{
+		{CK_RC4_128_WITH_MD5, "SSL_CK_RC4_128_WITH_MD5", 128, false},
+		{CK_RC4_128_EXPORT40_WITH_MD5, "SSL_CK_RC4_128_EXPORT40_WITH_MD5", 128, true},
+		{CK_RC2_128_CBC_WITH_MD5, "SSL_CK_RC2_128_CBC_WITH_MD5", 128, false},
+		{CK_RC2_128_CBC_EXPORT40_WITH_MD5, "SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5", 128, true},
+		{CK_IDEA_128_CBC_WITH_MD5, "SSL_CK_IDEA_128_CBC_WITH_MD5", 128, false},
+		{CK_DES_64_CBC_WITH_MD5, "SSL_CK_DES_64_CBC_WITH_MD5", 64, false},
+		{CK_DES_192_EDE3_CBC_WITH_MD5, "SSL_CK_DES_192_EDE3_CBC_WITH_MD5", 192, false},
+		{CipherKind(0xABCDEF), "SSL_CK_UNKNOWN", 0xCDEF, false},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.Name(); got != tc.name {
+			t.Errorf("CipherKind(0x%06x).Name() = %q, want %q", uint32(tc.kind), got, tc.name)
+		}
+		if got := tc.kind.EffectiveKeyBits(); got != tc.bits {
+			t.Errorf("CipherKind(0x%06x).EffectiveKeyBits() = %d, want %d", uint32(tc.kind), got, tc.bits)
+		}
+		if got := tc.kind.IsExport(); got != tc.export {
+			t.Errorf("CipherKind(0x%06x).IsExport() = %v, want %v", uint32(tc.kind), got, tc.export)
+		}
+	}
+}
+
+func TestAllKnownCipherKinds(t *testing.T) {
+	got := AllKnownCipherKinds()
+	if len(got) != 7 {
+		t.Fatalf("AllKnownCipherKinds() returned %d entries, want 7", len(got))
+	}
+	seen := make(map[CipherKind]bool, len(got))
+	for _, k := range got {
+		if seen[k] {
+			t.Errorf("duplicate cipher kind %s", k.Name())
+		}
+		seen[k] = true
+		if k.Name() == "SSL_CK_UNKNOWN" {
+			t.Errorf("AllKnownCipherKinds returned unknown kind 0x%06x", uint32(k))
+		}
+	}
+}
+
+func TestErrorCodeString(t *testing.T) {
+	cases := map[ErrorCode]string{
+		ErrNoCipher:        "NO-CIPHER-ERROR",
+		ErrNoCertificate:   "NO-CERTIFICATE-ERROR",
+		ErrBadCertificate:  "BAD-CERTIFICATE-ERROR",
+		ErrUnsupportedCert: "UNSUPPORTED-CERTIFICATE-TYPE-ERROR",
+		ErrorCode(0xFFFF):  "UNKNOWN-ERROR(0xffff)",
+	}
+	for code, want := range cases {
+		if got := code.String(); got != want {
+			t.Errorf("ErrorCode(0x%04x).String() = %q, want %q", uint16(code), got, want)
+		}
+	}
+	if got := ErrNoCipher.Error(); got != "ssl2: peer sent NO-CIPHER-ERROR" {
+		t.Errorf("ErrNoCipher.Error() = %q", got)
+	}
+}

--- a/crypto/ssl2/cipher_test.go
+++ b/crypto/ssl2/cipher_test.go
@@ -3,6 +3,11 @@
 // license that can be found in the LICENSE file.
 
 package ssl2
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
 
 import "testing"
 

--- a/crypto/ssl2/conn.go
+++ b/crypto/ssl2/conn.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/runZeroInc/excrypto/crypto/x509"
+)
+
+// Conn is a thin wrapper over a net.Conn that speaks SSL 2.0 records.
+//
+// It is intentionally simple: it provides synchronous read/write of single
+// records, a high-level [Conn.Probe] that performs CLIENT-HELLO →
+// SERVER-HELLO, and nothing else. It does NOT perform key exchange or
+// bulk-data encryption.
+type Conn struct {
+	conn net.Conn
+}
+
+// NewConn wraps c in an SSL 2.0 [Conn]. The caller retains ownership of c
+// and is responsible for closing it.
+func NewConn(c net.Conn) *Conn {
+	return &Conn{conn: c}
+}
+
+// NetConn returns the underlying net.Conn.
+func (c *Conn) NetConn() net.Conn { return c.conn }
+
+// SetDeadline is shorthand for c.NetConn().SetDeadline(t).
+func (c *Conn) SetDeadline(t time.Time) error { return c.conn.SetDeadline(t) }
+
+// WriteRecord writes payload as a single SSL 2.0 record.
+func (c *Conn) WriteRecord(payload []byte) error {
+	return writeRecord(c.conn, payload)
+}
+
+// ReadRecord reads a single SSL 2.0 record and returns its payload (with
+// any padding stripped).
+func (c *Conn) ReadRecord() ([]byte, error) {
+	_, payload, err := readRecord(c.conn)
+	return payload, err
+}
+
+// readRecordWithHeader is exposed for tests that want the parsed header.
+func (c *Conn) readRecordWithHeader() (recordHeader, []byte, error) {
+	return readRecord(c.conn)
+}
+
+// ProbeResult captures everything an SSL 2.0 probe can learn from a peer
+// without completing key exchange.
+type ProbeResult struct {
+	// ServerHello is the parsed SERVER-HELLO returned by the peer (nil if
+	// the peer responded with an ERROR or non-SSL2 traffic).
+	ServerHello *ServerHello
+	// Certificate is the parsed X.509 certificate from ServerHello, when
+	// the certificate type is X.509 and parsing succeeds.
+	Certificate *x509.Certificate
+	// CertificateParseError is set if certificate-type was X.509 but the
+	// DER could not be parsed by crypto/x509. The raw bytes are still
+	// available in ServerHello.Certificate.
+	CertificateParseError error
+	// PeerError is populated if the peer responded with an SSL 2.0 ERROR
+	// message instead of a SERVER-HELLO.
+	PeerError *ServerError
+}
+
+// SupportsSSL2 reports whether the peer responded with a well-formed
+// SERVER-HELLO (i.e. it speaks SSL 2.0).
+func (r *ProbeResult) SupportsSSL2() bool {
+	return r != nil && r.ServerHello != nil
+}
+
+// CipherKinds is a convenience accessor for the cipher kinds offered by
+// the server. Returns nil if no SERVER-HELLO was received.
+func (r *ProbeResult) CipherKinds() []CipherKind {
+	if r == nil || r.ServerHello == nil {
+		return nil
+	}
+	return r.ServerHello.CipherSpecs
+}
+
+// Probe sends a CLIENT-HELLO offering every well-known SSL 2.0 cipher and
+// reads back the peer's SERVER-HELLO (or ERROR). The connection is left
+// open so callers can inspect or close it as they see fit.
+//
+// challenge, if nil, is filled with 16 cryptographically-random bytes.
+func (c *Conn) Probe(challenge []byte) (*ProbeResult, error) {
+	if challenge == nil {
+		challenge = make([]byte, 16)
+		if _, err := rand.Read(challenge); err != nil {
+			return nil, fmt.Errorf("ssl2: generating challenge: %w", err)
+		}
+	}
+	hello := &ClientHello{
+		Version:     Version,
+		CipherSpecs: AllKnownCipherKinds(),
+		Challenge:   challenge,
+	}
+	wire, err := hello.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.WriteRecord(wire); err != nil {
+		return nil, fmt.Errorf("ssl2: writing CLIENT-HELLO: %w", err)
+	}
+	payload, err := c.ReadRecord()
+	if err != nil {
+		return nil, fmt.Errorf("ssl2: reading server response: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil, errors.New("ssl2: empty server response")
+	}
+	res := &ProbeResult{}
+	switch MessageType(payload[0]) {
+	case MsgServerHello:
+		sh, err := ParseServerHello(payload)
+		if err != nil {
+			return nil, err
+		}
+		res.ServerHello = sh
+		if sh.CertificateType == CertTypeX509 && len(sh.Certificate) > 0 {
+			cert, perr := x509.ParseCertificate(sh.Certificate)
+			if perr != nil {
+				res.CertificateParseError = perr
+			} else {
+				res.Certificate = cert
+			}
+		}
+	case MsgError:
+		e, err := ParseError(payload)
+		if err != nil {
+			return nil, err
+		}
+		res.PeerError = e
+	default:
+		return nil, fmt.Errorf("ssl2: unexpected initial server message type %d", payload[0])
+	}
+	return res, nil
+}
+
+// Dial connects to addr (e.g. "example.com:443") via tcp and runs [Conn.Probe].
+// The returned Conn is left open for further inspection; callers must close it.
+//
+// timeout, if non-zero, bounds the dial *and* the probe.
+func Dial(addr string, timeout time.Duration) (*Conn, *ProbeResult, error) {
+	dialer := net.Dialer{Timeout: timeout}
+	nc, err := dialer.Dial("tcp", addr)
+	if err != nil {
+		return nil, nil, err
+	}
+	c := NewConn(nc)
+	if timeout > 0 {
+		_ = c.SetDeadline(time.Now().Add(timeout))
+	}
+	res, err := c.Probe(nil)
+	if err != nil {
+		_ = nc.Close()
+		return nil, nil, err
+	}
+	if timeout > 0 {
+		_ = c.SetDeadline(time.Time{})
+	}
+	return c, res, nil
+}
+
+// Close closes the underlying connection.
+func (c *Conn) Close() error { return c.conn.Close() }
+
+// Server-side helpers ────────────────────────────────────────────────────
+
+// AcceptClientHello reads a single record from the peer and parses it as a
+// CLIENT-HELLO. It is provided primarily for the in-process tests in this
+// package and for fuzz/integration harnesses.
+func (c *Conn) AcceptClientHello() (*ClientHello, error) {
+	payload, err := c.ReadRecord()
+	if err != nil {
+		return nil, err
+	}
+	return ParseClientHello(payload)
+}
+
+// SendServerHello writes a SERVER-HELLO record to the peer.
+func (c *Conn) SendServerHello(sh *ServerHello) error {
+	wire, err := sh.Marshal()
+	if err != nil {
+		return err
+	}
+	return c.WriteRecord(wire)
+}
+
+// SendError writes an ERROR record to the peer.
+func (c *Conn) SendError(code ErrorCode) error {
+	return c.WriteRecord((&ServerError{Code: code}).Marshal())
+}
+
+// Compile-time check that *Conn does not accidentally implement io.ReadWriter
+// (we deliberately do NOT expose Read/Write of plaintext, since SSL 2.0
+// application data would be encrypted and we don't implement the cipher).
+var _ = func() io.ReadWriter { return nil }

--- a/crypto/ssl2/conn_test.go
+++ b/crypto/ssl2/conn_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"bytes"
+	"crypto/rand"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/runZeroInc/excrypto/crypto/ecdsa"
+	"github.com/runZeroInc/excrypto/crypto/elliptic"
+	"github.com/runZeroInc/excrypto/crypto/x509"
+	"github.com/runZeroInc/excrypto/crypto/x509/pkix"
+)
+
+// helperSelfSignedCert returns a DER-encoded self-signed cert. We deliberately
+// use ECDSA (not RSA) to avoid pulling in any RSA test fixtures and to keep
+// the cert small.
+func helperSelfSignedCert(t *testing.T) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "ssl2.test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return der
+}
+
+func TestProbeRoundTripOverNetPipe(t *testing.T) {
+	clientNC, serverNC := net.Pipe()
+	defer clientNC.Close()
+	defer serverNC.Close()
+
+	cert := helperSelfSignedCert(t)
+	connID := bytes.Repeat([]byte{0x99}, 16)
+
+	var (
+		wg     sync.WaitGroup
+		gotCH  *ClientHello
+		srvErr error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := NewConn(serverNC)
+		ch, err := s.AcceptClientHello()
+		if err != nil {
+			srvErr = err
+			return
+		}
+		gotCH = ch
+		srvErr = s.SendServerHello(&ServerHello{
+			SessionIDHit:    false,
+			CertificateType: CertTypeX509,
+			Version:         Version,
+			Certificate:     cert,
+			CipherSpecs:     []CipherKind{CK_RC4_128_WITH_MD5, CK_DES_192_EDE3_CBC_WITH_MD5},
+			ConnectionID:    connID,
+		})
+	}()
+
+	c := NewConn(clientNC)
+	res, err := c.Probe(nil)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	wg.Wait()
+	if srvErr != nil {
+		t.Fatalf("server-side: %v", srvErr)
+	}
+
+	if !res.SupportsSSL2() {
+		t.Fatal("expected SupportsSSL2() = true")
+	}
+	if res.PeerError != nil {
+		t.Fatalf("unexpected PeerError: %v", res.PeerError.Code)
+	}
+	if res.ServerHello.CertificateType != CertTypeX509 {
+		t.Errorf("cert type = %d", res.ServerHello.CertificateType)
+	}
+	if res.Certificate == nil {
+		t.Fatalf("expected parsed certificate; parse err = %v", res.CertificateParseError)
+	}
+	if res.Certificate.Subject.CommonName != "ssl2.test" {
+		t.Errorf("unexpected CN: %q", res.Certificate.Subject.CommonName)
+	}
+	if !bytes.Equal(res.ServerHello.ConnectionID, connID) {
+		t.Errorf("conn id mismatch")
+	}
+	wantOffer := AllKnownCipherKinds()
+	if len(gotCH.CipherSpecs) != len(wantOffer) {
+		t.Errorf("server saw %d ciphers, expected %d", len(gotCH.CipherSpecs), len(wantOffer))
+	}
+	if len(gotCH.Challenge) != 16 {
+		t.Errorf("challenge len = %d", len(gotCH.Challenge))
+	}
+	got := res.CipherKinds()
+	if len(got) != 2 {
+		t.Errorf("res.CipherKinds() = %d, want 2", len(got))
+	}
+}
+
+func TestProbeWithExplicitChallenge(t *testing.T) {
+	clientNC, serverNC := net.Pipe()
+	defer clientNC.Close()
+	defer serverNC.Close()
+
+	want := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 4) // 16 bytes
+
+	var srvCh *ClientHello
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := NewConn(serverNC)
+		ch, _ := s.AcceptClientHello()
+		srvCh = ch
+		_ = s.SendServerHello(&ServerHello{
+			CertificateType: CertTypeX509,
+			Version:         Version,
+			CipherSpecs:     []CipherKind{CK_RC4_128_WITH_MD5},
+			ConnectionID:    bytes.Repeat([]byte{0x01}, 16),
+		})
+	}()
+
+	c := NewConn(clientNC)
+	if _, err := c.Probe(want); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	wg.Wait()
+	if !bytes.Equal(srvCh.Challenge, want) {
+		t.Errorf("challenge mismatch: got %x", srvCh.Challenge)
+	}
+}
+
+func TestProbeServerError(t *testing.T) {
+	clientNC, serverNC := net.Pipe()
+	defer clientNC.Close()
+	defer serverNC.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := NewConn(serverNC)
+		_, _ = s.AcceptClientHello()
+		_ = s.SendError(ErrNoCipher)
+	}()
+
+	c := NewConn(clientNC)
+	res, err := c.Probe(nil)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	wg.Wait()
+	if res.SupportsSSL2() {
+		t.Errorf("SupportsSSL2() = true, want false on ERROR")
+	}
+	if res.PeerError == nil || res.PeerError.Code != ErrNoCipher {
+		t.Errorf("PeerError = %+v", res.PeerError)
+	}
+}
+
+func TestProbeUnexpectedMessage(t *testing.T) {
+	clientNC, serverNC := net.Pipe()
+	defer clientNC.Close()
+	defer serverNC.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := NewConn(serverNC)
+		_, _ = s.AcceptClientHello()
+		// Send a CLIENT-FINISHED, which the client should never accept here.
+		_ = s.WriteRecord((&ClientFinished{ConnectionID: bytes.Repeat([]byte{1}, 16)}).Marshal())
+	}()
+
+	c := NewConn(clientNC)
+	if _, err := c.Probe(nil); err == nil {
+		t.Error("expected error for unexpected initial message")
+	}
+	wg.Wait()
+}
+
+func TestProbeBadCertificate(t *testing.T) {
+	clientNC, serverNC := net.Pipe()
+	defer clientNC.Close()
+	defer serverNC.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := NewConn(serverNC)
+		_, _ = s.AcceptClientHello()
+		_ = s.SendServerHello(&ServerHello{
+			CertificateType: CertTypeX509,
+			Version:         Version,
+			Certificate:     []byte{0x00, 0x00, 0x00, 0x00}, // invalid DER
+			CipherSpecs:     []CipherKind{CK_RC4_128_WITH_MD5},
+			ConnectionID:    bytes.Repeat([]byte{0x01}, 16),
+		})
+	}()
+
+	c := NewConn(clientNC)
+	res, err := c.Probe(nil)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	wg.Wait()
+	if !res.SupportsSSL2() {
+		t.Fatal("server returned SERVER-HELLO; SupportsSSL2 should be true")
+	}
+	if res.Certificate != nil {
+		t.Error("expected Certificate=nil for bad DER")
+	}
+	if res.CertificateParseError == nil {
+		t.Error("expected CertificateParseError to be set")
+	}
+}
+
+func TestProbeNilResultHelpers(t *testing.T) {
+	var nilRes *ProbeResult
+	if nilRes.SupportsSSL2() {
+		t.Error("nil ProbeResult must not report SSL2 support")
+	}
+	if nilRes.CipherKinds() != nil {
+		t.Error("nil ProbeResult must return nil CipherKinds")
+	}
+}

--- a/crypto/ssl2/doc.go
+++ b/crypto/ssl2/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ssl2 implements the obsolete SSL 2.0 protocol as described in
+// Netscape's "The SSL Protocol" (Hickman, February 1995).
+//
+// SSL 2.0 was deprecated in 2011 by RFC 6176 and is cryptographically
+// broken: it has no MAC over the handshake, conflates authentication and
+// encryption keys, supports 40-bit "export" ciphers, and is vulnerable to
+// (among other things) cipher-suite rollback and the DROWN attack
+// (CVE-2016-0800). This package exists solely to enable security testing,
+// inventory, and research of legacy systems that still negotiate SSL 2.0.
+//
+// It is NOT a general-purpose TLS stack and MUST NOT be used to protect
+// any traffic. The implementation focuses on the wire format and on the
+// scanning use case (drive a CLIENT-HELLO, parse the SERVER-HELLO,
+// extract the offered cipher specs and X.509 certificate). Full bulk-data
+// encryption is intentionally not wired up.
+package ssl2

--- a/crypto/ssl2/doc.go
+++ b/crypto/ssl2/doc.go
@@ -1,3 +1,4 @@
+package ssl2
 // Copyright 2026 The runZero contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/crypto/ssl2/fuzz_test.go
+++ b/crypto/ssl2/fuzz_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzParseClientHello drives the CLIENT-HELLO parser with arbitrary inputs.
+// We assert that it never panics and that any successful parse round-trips.
+func FuzzParseClientHello(f *testing.F) {
+	f.Add(fixedClientHello)
+	f.Add([]byte{0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ch, err := ParseClientHello(data)
+		if err != nil {
+			return
+		}
+		out, err := ch.Marshal()
+		if err != nil {
+			// Some valid-on-the-wire combinations (e.g. unusual session
+			// id length) will be rejected by Marshal; that's intentional.
+			return
+		}
+		// The re-parsed message must be identical.
+		again, err := ParseClientHello(out)
+		if err != nil {
+			t.Fatalf("re-parse failed: %v", err)
+		}
+		if again.Version != ch.Version || !bytes.Equal(again.Challenge, ch.Challenge) {
+			t.Fatalf("round-trip diverged")
+		}
+	})
+}
+
+func FuzzParseServerHello(f *testing.F) {
+	good := (&ServerHello{
+		CertificateType: CertTypeX509,
+		Version:         Version,
+		Certificate:     []byte{0x30, 0x03, 0x02, 0x01, 0x00},
+		CipherSpecs:     []CipherKind{CK_RC4_128_WITH_MD5},
+		ConnectionID:    bytes.Repeat([]byte{0x77}, 16),
+	})
+	wire, _ := good.Marshal()
+	f.Add(wire)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseServerHello(data) // must not panic
+	})
+}
+
+func FuzzParseClientMasterKey(f *testing.F) {
+	good, _ := (&ClientMasterKey{
+		CipherKind:   CK_RC4_128_WITH_MD5,
+		ClearKey:     []byte{1, 2, 3},
+		EncryptedKey: bytes.Repeat([]byte{4}, 64),
+	}).Marshal()
+	f.Add(good)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseClientMasterKey(data) // must not panic
+	})
+}
+
+func FuzzReadRecord(f *testing.F) {
+	f.Add([]byte{0x80, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05})
+	f.Add([]byte{0x00, 0x05, 0x02, 0x01, 0x02, 0x03, 0x04, 0x05})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _ = readRecord(bytes.NewReader(data)) // must not panic
+	})
+}

--- a/crypto/ssl2/handshake.go
+++ b/crypto/ssl2/handshake.go
@@ -23,10 +23,10 @@ import (
 //	    opaque challenge[challenge_length];
 //	} ClientHello;
 type ClientHello struct {
-	Version      uint16
-	CipherSpecs  []CipherKind
-	SessionID    []byte
-	Challenge    []byte
+	Version     uint16
+	CipherSpecs []CipherKind
+	SessionID   []byte
+	Challenge   []byte
 }
 
 // Marshal returns the wire encoding (excluding the record header) of the

--- a/crypto/ssl2/handshake.go
+++ b/crypto/ssl2/handshake.go
@@ -1,0 +1,314 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// ClientHello is the SSL 2.0 CLIENT-HELLO handshake message.
+//
+//	struct {
+//	    uint8  msg_type;            // == 1
+//	    uint16 version;             // == 0x0002
+//	    uint16 cipher_specs_length;
+//	    uint16 session_id_length;
+//	    uint16 challenge_length;    // 16..32
+//	    opaque cipher_specs[cipher_specs_length];
+//	    opaque session_id[session_id_length];
+//	    opaque challenge[challenge_length];
+//	} ClientHello;
+type ClientHello struct {
+	Version      uint16
+	CipherSpecs  []CipherKind
+	SessionID    []byte
+	Challenge    []byte
+}
+
+// Marshal returns the wire encoding (excluding the record header) of the
+// CLIENT-HELLO message.
+func (c *ClientHello) Marshal() ([]byte, error) {
+	if len(c.Challenge) < 16 || len(c.Challenge) > 32 {
+		return nil, fmt.Errorf("ssl2: CLIENT-HELLO challenge length %d outside [16,32]", len(c.Challenge))
+	}
+	if len(c.CipherSpecs) == 0 {
+		return nil, errors.New("ssl2: CLIENT-HELLO must offer at least one cipher")
+	}
+	if len(c.SessionID) != 0 && len(c.SessionID) != 16 {
+		return nil, fmt.Errorf("ssl2: CLIENT-HELLO session_id length must be 0 or 16, got %d", len(c.SessionID))
+	}
+	cipherBytes := 3 * len(c.CipherSpecs)
+	out := make([]byte, 0, 9+cipherBytes+len(c.SessionID)+len(c.Challenge))
+	out = append(out, byte(MsgClientHello))
+	out = binary.BigEndian.AppendUint16(out, c.Version)
+	out = binary.BigEndian.AppendUint16(out, uint16(cipherBytes))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(c.SessionID)))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(c.Challenge)))
+	for _, spec := range c.CipherSpecs {
+		out = append(out, byte(spec>>16), byte(spec>>8), byte(spec))
+	}
+	out = append(out, c.SessionID...)
+	out = append(out, c.Challenge...)
+	return out, nil
+}
+
+// ParseClientHello parses an SSL 2.0 CLIENT-HELLO message body (record
+// payload, with the message-type octet still attached).
+func ParseClientHello(payload []byte) (*ClientHello, error) {
+	if len(payload) < 9 {
+		return nil, errors.New("ssl2: CLIENT-HELLO truncated")
+	}
+	if MessageType(payload[0]) != MsgClientHello {
+		return nil, fmt.Errorf("ssl2: not a CLIENT-HELLO (msg type %d)", payload[0])
+	}
+	c := &ClientHello{
+		Version: binary.BigEndian.Uint16(payload[1:3]),
+	}
+	csLen := int(binary.BigEndian.Uint16(payload[3:5]))
+	sidLen := int(binary.BigEndian.Uint16(payload[5:7]))
+	chLen := int(binary.BigEndian.Uint16(payload[7:9]))
+	if csLen%3 != 0 {
+		return nil, fmt.Errorf("ssl2: cipher_specs_length %d not a multiple of 3", csLen)
+	}
+	if 9+csLen+sidLen+chLen > len(payload) {
+		return nil, errors.New("ssl2: CLIENT-HELLO body shorter than declared")
+	}
+	off := 9
+	c.CipherSpecs = make([]CipherKind, 0, csLen/3)
+	for i := 0; i < csLen; i += 3 {
+		c.CipherSpecs = append(c.CipherSpecs, CipherKind(uint32(payload[off+i])<<16|uint32(payload[off+i+1])<<8|uint32(payload[off+i+2])))
+	}
+	off += csLen
+	if sidLen > 0 {
+		c.SessionID = append([]byte(nil), payload[off:off+sidLen]...)
+		off += sidLen
+	}
+	if chLen < 16 || chLen > 32 {
+		return nil, fmt.Errorf("ssl2: CLIENT-HELLO challenge length %d outside [16,32]", chLen)
+	}
+	c.Challenge = append([]byte(nil), payload[off:off+chLen]...)
+	return c, nil
+}
+
+// ServerHello is the SSL 2.0 SERVER-HELLO handshake message.
+//
+//	struct {
+//	    uint8  msg_type;             // == 4
+//	    uint8  session_id_hit;       // 0 (false) or 1 (true)
+//	    uint8  certificate_type;     // 1 == X.509
+//	    uint16 version;
+//	    uint16 certificate_length;
+//	    uint16 cipher_specs_length;
+//	    uint16 connection_id_length; // 16..32
+//	    opaque certificate[certificate_length];
+//	    opaque cipher_specs[cipher_specs_length];
+//	    opaque connection_id[connection_id_length];
+//	} ServerHello;
+type ServerHello struct {
+	SessionIDHit    bool
+	CertificateType CertType
+	Version         uint16
+	Certificate     []byte
+	CipherSpecs     []CipherKind
+	ConnectionID    []byte
+}
+
+// Marshal returns the wire encoding of the SERVER-HELLO message.
+func (s *ServerHello) Marshal() ([]byte, error) {
+	if len(s.ConnectionID) < 16 || len(s.ConnectionID) > 32 {
+		return nil, fmt.Errorf("ssl2: SERVER-HELLO connection_id length %d outside [16,32]", len(s.ConnectionID))
+	}
+	cipherBytes := 3 * len(s.CipherSpecs)
+	out := make([]byte, 0, 11+len(s.Certificate)+cipherBytes+len(s.ConnectionID))
+	out = append(out, byte(MsgServerHello))
+	if s.SessionIDHit {
+		out = append(out, 1)
+	} else {
+		out = append(out, 0)
+	}
+	out = append(out, byte(s.CertificateType))
+	out = binary.BigEndian.AppendUint16(out, s.Version)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(s.Certificate)))
+	out = binary.BigEndian.AppendUint16(out, uint16(cipherBytes))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(s.ConnectionID)))
+	out = append(out, s.Certificate...)
+	for _, spec := range s.CipherSpecs {
+		out = append(out, byte(spec>>16), byte(spec>>8), byte(spec))
+	}
+	out = append(out, s.ConnectionID...)
+	return out, nil
+}
+
+// ParseServerHello parses a SERVER-HELLO record payload (with the
+// message-type octet still attached).
+func ParseServerHello(payload []byte) (*ServerHello, error) {
+	if len(payload) < 11 {
+		return nil, errors.New("ssl2: SERVER-HELLO truncated")
+	}
+	if MessageType(payload[0]) != MsgServerHello {
+		return nil, fmt.Errorf("ssl2: not a SERVER-HELLO (msg type %d)", payload[0])
+	}
+	s := &ServerHello{
+		SessionIDHit:    payload[1] != 0,
+		CertificateType: CertType(payload[2]),
+		Version:         binary.BigEndian.Uint16(payload[3:5]),
+	}
+	certLen := int(binary.BigEndian.Uint16(payload[5:7]))
+	csLen := int(binary.BigEndian.Uint16(payload[7:9]))
+	connLen := int(binary.BigEndian.Uint16(payload[9:11]))
+	if csLen%3 != 0 {
+		return nil, fmt.Errorf("ssl2: cipher_specs_length %d not a multiple of 3", csLen)
+	}
+	if 11+certLen+csLen+connLen > len(payload) {
+		return nil, errors.New("ssl2: SERVER-HELLO body shorter than declared")
+	}
+	off := 11
+	if certLen > 0 {
+		s.Certificate = append([]byte(nil), payload[off:off+certLen]...)
+		off += certLen
+	}
+	s.CipherSpecs = make([]CipherKind, 0, csLen/3)
+	for i := 0; i < csLen; i += 3 {
+		s.CipherSpecs = append(s.CipherSpecs, CipherKind(uint32(payload[off+i])<<16|uint32(payload[off+i+1])<<8|uint32(payload[off+i+2])))
+	}
+	off += csLen
+	if connLen < 16 || connLen > 32 {
+		return nil, fmt.Errorf("ssl2: SERVER-HELLO connection_id length %d outside [16,32]", connLen)
+	}
+	s.ConnectionID = append([]byte(nil), payload[off:off+connLen]...)
+	return s, nil
+}
+
+// ClientMasterKey is the SSL 2.0 CLIENT-MASTER-KEY handshake message.
+//
+//	struct {
+//	    uint8  msg_type;                         // == 2
+//	    uint24 cipher_kind;                      // selected CIPHER-KIND
+//	    uint16 clear_key_length;
+//	    uint16 encrypted_key_length;
+//	    uint16 key_arg_length;
+//	    opaque clear_key[clear_key_length];
+//	    opaque encrypted_key[encrypted_key_length];
+//	    opaque key_arg[key_arg_length];
+//	} ClientMasterKey;
+type ClientMasterKey struct {
+	CipherKind   CipherKind
+	ClearKey     []byte
+	EncryptedKey []byte
+	KeyArg       []byte
+}
+
+// Marshal returns the wire encoding of CLIENT-MASTER-KEY.
+func (c *ClientMasterKey) Marshal() ([]byte, error) {
+	out := make([]byte, 0, 10+len(c.ClearKey)+len(c.EncryptedKey)+len(c.KeyArg))
+	out = append(out, byte(MsgClientMasterKey))
+	out = append(out, byte(c.CipherKind>>16), byte(c.CipherKind>>8), byte(c.CipherKind))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(c.ClearKey)))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(c.EncryptedKey)))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(c.KeyArg)))
+	out = append(out, c.ClearKey...)
+	out = append(out, c.EncryptedKey...)
+	out = append(out, c.KeyArg...)
+	return out, nil
+}
+
+// ParseClientMasterKey parses a CLIENT-MASTER-KEY record payload.
+func ParseClientMasterKey(payload []byte) (*ClientMasterKey, error) {
+	if len(payload) < 10 {
+		return nil, errors.New("ssl2: CLIENT-MASTER-KEY truncated")
+	}
+	if MessageType(payload[0]) != MsgClientMasterKey {
+		return nil, fmt.Errorf("ssl2: not a CLIENT-MASTER-KEY (msg type %d)", payload[0])
+	}
+	c := &ClientMasterKey{
+		CipherKind: CipherKind(uint32(payload[1])<<16 | uint32(payload[2])<<8 | uint32(payload[3])),
+	}
+	clearLen := int(binary.BigEndian.Uint16(payload[4:6]))
+	encLen := int(binary.BigEndian.Uint16(payload[6:8]))
+	argLen := int(binary.BigEndian.Uint16(payload[8:10]))
+	if 10+clearLen+encLen+argLen > len(payload) {
+		return nil, errors.New("ssl2: CLIENT-MASTER-KEY body shorter than declared")
+	}
+	off := 10
+	c.ClearKey = append([]byte(nil), payload[off:off+clearLen]...)
+	off += clearLen
+	c.EncryptedKey = append([]byte(nil), payload[off:off+encLen]...)
+	off += encLen
+	c.KeyArg = append([]byte(nil), payload[off:off+argLen]...)
+	return c, nil
+}
+
+// ServerError represents an ERROR handshake message (msg_type 0).
+type ServerError struct {
+	Code ErrorCode
+}
+
+// Marshal encodes an ERROR message.
+func (e *ServerError) Marshal() []byte {
+	return []byte{byte(MsgError), byte(e.Code >> 8), byte(e.Code)}
+}
+
+// ParseError parses an ERROR record payload.
+func ParseError(payload []byte) (*ServerError, error) {
+	if len(payload) < 3 {
+		return nil, errors.New("ssl2: ERROR message truncated")
+	}
+	if MessageType(payload[0]) != MsgError {
+		return nil, fmt.Errorf("ssl2: not an ERROR message (msg type %d)", payload[0])
+	}
+	return &ServerError{Code: ErrorCode(binary.BigEndian.Uint16(payload[1:3]))}, nil
+}
+
+// ClientFinished, ServerVerify, ServerFinished and the certificate-request
+// pair are simple opaque-payload messages. We expose minimal types for
+// completeness so callers can drive a full handshake skeleton.
+
+// ClientFinished is CLIENT-FINISHED (msg_type 3): a single connection-id
+// echo encrypted with the client write key. We do not implement encryption,
+// but we expose Marshal/Parse over the cleartext body for tests.
+type ClientFinished struct{ ConnectionID []byte }
+
+func (m *ClientFinished) Marshal() []byte {
+	return append([]byte{byte(MsgClientFinished)}, m.ConnectionID...)
+}
+
+func ParseClientFinished(payload []byte) (*ClientFinished, error) {
+	if len(payload) < 1 || MessageType(payload[0]) != MsgClientFinished {
+		return nil, errors.New("ssl2: not a CLIENT-FINISHED")
+	}
+	return &ClientFinished{ConnectionID: append([]byte(nil), payload[1:]...)}, nil
+}
+
+// ServerVerify is SERVER-VERIFY (msg_type 5): the server's encryption of
+// the client's CHALLENGE.
+type ServerVerify struct{ Challenge []byte }
+
+func (m *ServerVerify) Marshal() []byte {
+	return append([]byte{byte(MsgServerVerify)}, m.Challenge...)
+}
+
+func ParseServerVerify(payload []byte) (*ServerVerify, error) {
+	if len(payload) < 1 || MessageType(payload[0]) != MsgServerVerify {
+		return nil, errors.New("ssl2: not a SERVER-VERIFY")
+	}
+	return &ServerVerify{Challenge: append([]byte(nil), payload[1:]...)}, nil
+}
+
+// ServerFinished is SERVER-FINISHED (msg_type 6): a fresh session-id the
+// client may resume with.
+type ServerFinished struct{ SessionID []byte }
+
+func (m *ServerFinished) Marshal() []byte {
+	return append([]byte{byte(MsgServerFinished)}, m.SessionID...)
+}
+
+func ParseServerFinished(payload []byte) (*ServerFinished, error) {
+	if len(payload) < 1 || MessageType(payload[0]) != MsgServerFinished {
+		return nil, errors.New("ssl2: not a SERVER-FINISHED")
+	}
+	return &ServerFinished{SessionID: append([]byte(nil), payload[1:]...)}, nil
+}

--- a/crypto/ssl2/handshake_test.go
+++ b/crypto/ssl2/handshake_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// fixedClientHello is a real SSL 2.0 CLIENT-HELLO captured from openssl 0.9.8
+// (s_client -ssl2). Bytes adapted to be self-describing here:
+//
+//	01                                  msg_type      = CLIENT-HELLO
+//	00 02                               version       = 0x0002
+//	00 15                               cs_len        = 21
+//	00 00                               sid_len       = 0
+//	00 10                               ch_len        = 16
+//	01 00 80                            CK_RC4_128_WITH_MD5
+//	02 00 80                            CK_RC4_128_EXPORT40
+//	03 00 80                            CK_RC2_128_CBC
+//	04 00 80                            CK_RC2_128_CBC_EXPORT40
+//	05 00 80                            CK_IDEA_128_CBC
+//	06 00 40                            CK_DES_64_CBC
+//	07 00 c0                            CK_DES_192_EDE3_CBC
+//	... 16 octets of challenge ...
+var fixedClientHello = []byte{
+	0x01, 0x00, 0x02, 0x00, 0x15, 0x00, 0x00, 0x00, 0x10,
+	0x01, 0x00, 0x80, 0x02, 0x00, 0x80, 0x03, 0x00, 0x80,
+	0x04, 0x00, 0x80, 0x05, 0x00, 0x80, 0x06, 0x00, 0x40,
+	0x07, 0x00, 0xc0,
+	0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8,
+	0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0,
+}
+
+func TestParseFixedClientHello(t *testing.T) {
+	c, err := ParseClientHello(fixedClientHello)
+	if err != nil {
+		t.Fatalf("ParseClientHello: %v", err)
+	}
+	if c.Version != 0x0002 {
+		t.Errorf("version = 0x%04x", c.Version)
+	}
+	if len(c.CipherSpecs) != 7 {
+		t.Errorf("got %d cipher specs, want 7", len(c.CipherSpecs))
+	}
+	wantOrder := []CipherKind{
+		CK_RC4_128_WITH_MD5,
+		CK_RC4_128_EXPORT40_WITH_MD5,
+		CK_RC2_128_CBC_WITH_MD5,
+		CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+		CK_IDEA_128_CBC_WITH_MD5,
+		CK_DES_64_CBC_WITH_MD5,
+		CK_DES_192_EDE3_CBC_WITH_MD5,
+	}
+	for i, w := range wantOrder {
+		if c.CipherSpecs[i] != w {
+			t.Errorf("cipher[%d] = %s, want %s", i, c.CipherSpecs[i].Name(), w.Name())
+		}
+	}
+	if len(c.SessionID) != 0 {
+		t.Errorf("session id should be empty, got %x", c.SessionID)
+	}
+	if len(c.Challenge) != 16 {
+		t.Errorf("challenge length = %d", len(c.Challenge))
+	}
+}
+
+func TestClientHelloRoundTrip(t *testing.T) {
+	in := &ClientHello{
+		Version:     Version,
+		CipherSpecs: AllKnownCipherKinds(),
+		SessionID:   bytes.Repeat([]byte{0x33}, 16),
+		Challenge:   bytes.Repeat([]byte{0x44}, 24),
+	}
+	wire, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out, err := ParseClientHello(wire)
+	if err != nil {
+		t.Fatalf("ParseClientHello: %v", err)
+	}
+	if out.Version != in.Version {
+		t.Errorf("version mismatch")
+	}
+	if !bytes.Equal(out.SessionID, in.SessionID) {
+		t.Errorf("session_id mismatch")
+	}
+	if !bytes.Equal(out.Challenge, in.Challenge) {
+		t.Errorf("challenge mismatch")
+	}
+	if len(out.CipherSpecs) != len(in.CipherSpecs) {
+		t.Fatalf("cipher count: got %d want %d", len(out.CipherSpecs), len(in.CipherSpecs))
+	}
+	for i := range in.CipherSpecs {
+		if in.CipherSpecs[i] != out.CipherSpecs[i] {
+			t.Errorf("cipher[%d] mismatch", i)
+		}
+	}
+}
+
+func TestClientHelloMarshalErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ClientHello
+		want string
+	}{
+		{"short challenge", ClientHello{Version: Version, CipherSpecs: []CipherKind{CK_RC4_128_WITH_MD5}, Challenge: bytes.Repeat([]byte{1}, 8)}, "challenge length"},
+		{"long challenge", ClientHello{Version: Version, CipherSpecs: []CipherKind{CK_RC4_128_WITH_MD5}, Challenge: bytes.Repeat([]byte{1}, 33)}, "challenge length"},
+		{"no ciphers", ClientHello{Version: Version, Challenge: bytes.Repeat([]byte{1}, 16)}, "at least one cipher"},
+		{"bad sid len", ClientHello{Version: Version, CipherSpecs: []CipherKind{CK_RC4_128_WITH_MD5}, SessionID: []byte{1, 2, 3}, Challenge: bytes.Repeat([]byte{1}, 16)}, "session_id length"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.in.Marshal()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseClientHelloErrors(t *testing.T) {
+	// Wrong message type.
+	if _, err := ParseClientHello([]byte{0x04, 0, 2, 0, 0, 0, 0, 0, 16}); err == nil {
+		t.Error("expected error for wrong type")
+	}
+	// Truncated.
+	if _, err := ParseClientHello([]byte{0x01, 0x00}); err == nil {
+		t.Error("expected error for truncated hello")
+	}
+	// cipher_specs_length not multiple of 3.
+	bad := []byte{0x01, 0, 2, 0, 4, 0, 0, 0, 16}
+	bad = append(bad, make([]byte, 4+16)...)
+	if _, err := ParseClientHello(bad); err == nil {
+		t.Error("expected error for bad cs_len")
+	}
+	// Body shorter than declared.
+	short := []byte{0x01, 0, 2, 0, 3, 0, 0, 0, 16, 0x01, 0x00, 0x80}
+	if _, err := ParseClientHello(short); err == nil {
+		t.Error("expected error for truncated body")
+	}
+}
+
+func TestServerHelloRoundTrip(t *testing.T) {
+	cert := bytes.Repeat([]byte{0xCA}, 512)
+	in := &ServerHello{
+		SessionIDHit:    false,
+		CertificateType: CertTypeX509,
+		Version:         Version,
+		Certificate:     cert,
+		CipherSpecs:     []CipherKind{CK_RC4_128_WITH_MD5, CK_DES_192_EDE3_CBC_WITH_MD5},
+		ConnectionID:    bytes.Repeat([]byte{0x77}, 16),
+	}
+	wire, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out, err := ParseServerHello(wire)
+	if err != nil {
+		t.Fatalf("ParseServerHello: %v", err)
+	}
+	if out.CertificateType != CertTypeX509 || out.Version != Version {
+		t.Errorf("header mismatch: %+v", out)
+	}
+	if !bytes.Equal(out.Certificate, cert) {
+		t.Errorf("cert mismatch")
+	}
+	if !bytes.Equal(out.ConnectionID, in.ConnectionID) {
+		t.Errorf("conn id mismatch")
+	}
+	if len(out.CipherSpecs) != 2 || out.CipherSpecs[0] != CK_RC4_128_WITH_MD5 {
+		t.Errorf("ciphers mismatch: %v", out.CipherSpecs)
+	}
+}
+
+func TestServerHelloMarshalErrors(t *testing.T) {
+	in := &ServerHello{ConnectionID: []byte{1, 2, 3}}
+	if _, err := in.Marshal(); err == nil {
+		t.Error("expected connection_id length error")
+	}
+}
+
+func TestParseServerHelloErrors(t *testing.T) {
+	if _, err := ParseServerHello([]byte{0x01, 0, 1, 0, 2, 0, 0, 0, 0, 0, 16}); err == nil {
+		t.Error("expected error for wrong msg type")
+	}
+	if _, err := ParseServerHello([]byte{0x04}); err == nil {
+		t.Error("expected error for truncated")
+	}
+	// cs_len not multiple of 3.
+	bad := []byte{0x04, 0, 1, 0, 2, 0, 0, 0, 4, 0, 16}
+	bad = append(bad, make([]byte, 4+16)...)
+	if _, err := ParseServerHello(bad); err == nil {
+		t.Error("expected cs_len error")
+	}
+	// connection_id length out of range.
+	short := []byte{0x04, 0, 1, 0, 2, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0}
+	if _, err := ParseServerHello(short); err == nil {
+		t.Error("expected conn_id length error")
+	}
+}
+
+func TestClientMasterKeyRoundTrip(t *testing.T) {
+	in := &ClientMasterKey{
+		CipherKind:   CK_RC4_128_EXPORT40_WITH_MD5,
+		ClearKey:     bytes.Repeat([]byte{0x11}, 11),
+		EncryptedKey: bytes.Repeat([]byte{0x22}, 64),
+		KeyArg:       nil,
+	}
+	wire, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out, err := ParseClientMasterKey(wire)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if out.CipherKind != in.CipherKind {
+		t.Errorf("cipher kind mismatch")
+	}
+	if !bytes.Equal(out.ClearKey, in.ClearKey) || !bytes.Equal(out.EncryptedKey, in.EncryptedKey) {
+		t.Errorf("payload mismatch")
+	}
+}
+
+func TestParseClientMasterKeyErrors(t *testing.T) {
+	if _, err := ParseClientMasterKey([]byte{0x01}); err == nil {
+		t.Error("expected wrong-type error")
+	}
+	if _, err := ParseClientMasterKey([]byte{0x02, 0, 0, 0}); err == nil {
+		t.Error("expected truncated error")
+	}
+	short := []byte{0x02, 0x01, 0x00, 0x80, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00}
+	if _, err := ParseClientMasterKey(short); err == nil {
+		t.Error("expected body-shorter-than-declared error")
+	}
+}
+
+func TestErrorMessageRoundTrip(t *testing.T) {
+	for _, code := range []ErrorCode{ErrNoCipher, ErrNoCertificate, ErrBadCertificate, ErrUnsupportedCert} {
+		wire := (&ServerError{Code: code}).Marshal()
+		got, err := ParseError(wire)
+		if err != nil {
+			t.Fatalf("ParseError: %v", err)
+		}
+		if got.Code != code {
+			t.Errorf("got %v, want %v", got.Code, code)
+		}
+	}
+	if _, err := ParseError([]byte{0x00, 0x00}); err == nil {
+		t.Error("expected truncated error")
+	}
+	if _, err := ParseError([]byte{0x01, 0x00, 0x01}); err == nil {
+		t.Error("expected wrong-type error")
+	}
+}
+
+func TestSimpleMessagesRoundTrip(t *testing.T) {
+	cf := &ClientFinished{ConnectionID: bytes.Repeat([]byte{0x55}, 16)}
+	if got, err := ParseClientFinished(cf.Marshal()); err != nil || !bytes.Equal(got.ConnectionID, cf.ConnectionID) {
+		t.Errorf("CLIENT-FINISHED round-trip: %v / %x", err, got)
+	}
+	sv := &ServerVerify{Challenge: bytes.Repeat([]byte{0x66}, 16)}
+	if got, err := ParseServerVerify(sv.Marshal()); err != nil || !bytes.Equal(got.Challenge, sv.Challenge) {
+		t.Errorf("SERVER-VERIFY round-trip: %v / %x", err, got)
+	}
+	sf := &ServerFinished{SessionID: bytes.Repeat([]byte{0x77}, 16)}
+	if got, err := ParseServerFinished(sf.Marshal()); err != nil || !bytes.Equal(got.SessionID, sf.SessionID) {
+		t.Errorf("SERVER-FINISHED round-trip: %v / %x", err, got)
+	}
+	if _, err := ParseClientFinished([]byte{0x05}); err == nil {
+		t.Error("expected wrong-type error from ParseClientFinished")
+	}
+	if _, err := ParseServerVerify([]byte{0x01}); err == nil {
+		t.Error("expected wrong-type error from ParseServerVerify")
+	}
+	if _, err := ParseServerFinished([]byte{0x01}); err == nil {
+		t.Error("expected wrong-type error from ParseServerFinished")
+	}
+}

--- a/crypto/ssl2/record.go
+++ b/crypto/ssl2/record.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxRecordPayload is the largest plaintext payload that fits in a single
+// SSL 2.0 record. Two-byte-header records can carry 2^15-1 octets, but
+// most implementations cap the payload at 16 KiB. We accept up to the
+// protocol maximum on read and emit a generous-but-bounded value on write.
+const MaxRecordPayload = 32767
+
+// recordHeader represents the 2- or 3-octet SSL 2.0 record-layer header.
+//
+//	2-byte header (no padding):
+//	    byte 0:    1xxxxxxx     ─ top bit set; remainder = high 7 bits of length
+//	    byte 1:    yyyyyyyy     ─ low 8 bits of length
+//	3-byte header (block-cipher padded):
+//	    byte 0:    01xxxxxx     ─ top bit clear, second bit signals "security
+//	                              escape"; remainder = high 6 bits of length
+//	    byte 1:    yyyyyyyy     ─ low 8 bits of length
+//	    byte 2:    pppppppp     ─ pad-length octet
+//
+// The total record length is *length + padLen* octets of payload.
+//
+// Reference: "The SSL Protocol" §1.4.1.
+type recordHeader struct {
+	length     int
+	padLen     int  // 0 for 2-byte headers
+	hasPadding bool // false for 2-byte headers
+	isEscape   bool // "security escape" bit (rarely used)
+}
+
+// readRecord reads a single SSL 2.0 record from r and returns the payload.
+// The padding (if any) is stripped off and discarded.
+//
+// It returns the parsed header so callers can distinguish 2-byte and 3-byte
+// records on the wire — useful for tests and forensics.
+func readRecord(r io.Reader) (recordHeader, []byte, error) {
+	var hdr [3]byte
+	if _, err := io.ReadFull(r, hdr[:2]); err != nil {
+		return recordHeader{}, nil, err
+	}
+	var h recordHeader
+	if hdr[0]&0x80 != 0 {
+		// 2-byte header.
+		h.length = (int(hdr[0]&0x7f) << 8) | int(hdr[1])
+	} else {
+		// 3-byte header.
+		h.hasPadding = true
+		h.isEscape = hdr[0]&0x40 != 0
+		h.length = (int(hdr[0]&0x3f) << 8) | int(hdr[1])
+		if _, err := io.ReadFull(r, hdr[2:3]); err != nil {
+			return recordHeader{}, nil, err
+		}
+		h.padLen = int(hdr[2])
+	}
+	if h.length == 0 {
+		return h, nil, errors.New("ssl2: zero-length record")
+	}
+	if h.length > MaxRecordPayload {
+		return h, nil, fmt.Errorf("ssl2: record length %d exceeds maximum %d", h.length, MaxRecordPayload)
+	}
+	if h.padLen > h.length {
+		return h, nil, fmt.Errorf("ssl2: pad length %d exceeds record length %d", h.padLen, h.length)
+	}
+	buf := make([]byte, h.length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return h, nil, err
+	}
+	// In SSL 2.0 the *length* field counts ciphertext (data + padding);
+	// for unencrypted handshake records padLen is always zero. We trim any
+	// trailing pad in the unlikely event a server sent a padded clear-text
+	// record.
+	return h, buf[:len(buf)-h.padLen], nil
+}
+
+// writeRecord writes a single 2-byte-header SSL 2.0 record carrying payload.
+// payload must be non-empty and at most MaxRecordPayload octets.
+//
+// We always emit 2-byte headers because every clear-text handshake message
+// fits in this form and 3-byte headers are only meaningful once a block
+// cipher has been negotiated (a state this package does not enter).
+func writeRecord(w io.Writer, payload []byte) error {
+	if len(payload) == 0 {
+		return errors.New("ssl2: refusing to write empty record")
+	}
+	if len(payload) > MaxRecordPayload {
+		return fmt.Errorf("ssl2: payload length %d exceeds maximum %d", len(payload), MaxRecordPayload)
+	}
+	hdr := []byte{
+		0x80 | byte(len(payload)>>8),
+		byte(len(payload)),
+	}
+	if _, err := w.Write(hdr); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}

--- a/crypto/ssl2/record_test.go
+++ b/crypto/ssl2/record_test.go
@@ -84,11 +84,11 @@ func TestRecordReadErrors(t *testing.T) {
 		wire []byte
 		want string
 	}{
-		{"empty", []byte{}, ""},                                     // io.EOF
-		{"truncated 2-byte hdr", []byte{0x80}, ""},                  // unexpected EOF
+		{"empty", []byte{}, ""},                    // io.EOF
+		{"truncated 2-byte hdr", []byte{0x80}, ""}, // unexpected EOF
 		{"zero length", []byte{0x80, 0x00}, "zero-length record"},
-		{"truncated body", []byte{0x80, 0x05, 0x01, 0x02}, ""},      // unexpected EOF
-		{"truncated 3-byte hdr", []byte{0x00, 0x05}, ""},            // unexpected EOF
+		{"truncated body", []byte{0x80, 0x05, 0x01, 0x02}, ""}, // unexpected EOF
+		{"truncated 3-byte hdr", []byte{0x00, 0x05}, ""},       // unexpected EOF
 		{"pad bigger than length", []byte{0x00, 0x02, 0x05, 0x01, 0x02}, "pad length 5 exceeds record length 2"},
 	}
 	for _, tc := range cases {

--- a/crypto/ssl2/record_test.go
+++ b/crypto/ssl2/record_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The runZero contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ssl2
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRecordRoundTrip2ByteHeader(t *testing.T) {
+	payloads := [][]byte{
+		[]byte("a"),
+		bytes.Repeat([]byte{0x42}, 127),
+		bytes.Repeat([]byte{0x55}, 256),
+		bytes.Repeat([]byte{0xAA}, 4096),
+		bytes.Repeat([]byte{0xCC}, MaxRecordPayload),
+	}
+	for _, p := range payloads {
+		var buf bytes.Buffer
+		if err := writeRecord(&buf, p); err != nil {
+			t.Fatalf("writeRecord(len=%d): %v", len(p), err)
+		}
+		// Top bit of first header byte must be set for 2-byte headers.
+		if buf.Bytes()[0]&0x80 == 0 {
+			t.Errorf("len=%d: header top bit not set", len(p))
+		}
+		hdr, got, err := readRecord(&buf)
+		if err != nil {
+			t.Fatalf("readRecord(len=%d): %v", len(p), err)
+		}
+		if hdr.hasPadding {
+			t.Errorf("len=%d: round-trip should not introduce padding", len(p))
+		}
+		if hdr.length != len(p) {
+			t.Errorf("len=%d: header length=%d", len(p), hdr.length)
+		}
+		if !bytes.Equal(got, p) {
+			t.Errorf("len=%d: payload mismatch", len(p))
+		}
+	}
+}
+
+func TestRecordParse3ByteHeader(t *testing.T) {
+	// Hand-craft a 3-byte-header record carrying 16 octets of payload, of
+	// which 5 are padding. Length field encodes total payload+pad = 16.
+	body := bytes.Repeat([]byte{0xEE}, 11)
+	pad := bytes.Repeat([]byte{0x00}, 5)
+	wire := append([]byte{0x00, 0x10, 0x05}, append(body, pad...)...)
+	hdr, got, err := readRecord(bytes.NewReader(wire))
+	if err != nil {
+		t.Fatalf("readRecord: %v", err)
+	}
+	if !hdr.hasPadding || hdr.padLen != 5 || hdr.length != 16 {
+		t.Errorf("hdr = %+v", hdr)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("payload = %x, want %x", got, body)
+	}
+}
+
+func TestRecordParseEscapeBit(t *testing.T) {
+	// 3-byte header with the security-escape bit set.
+	wire := []byte{0x40, 0x04, 0x00, 0x01, 0x02, 0x03, 0x04}
+	hdr, got, err := readRecord(bytes.NewReader(wire))
+	if err != nil {
+		t.Fatalf("readRecord: %v", err)
+	}
+	if !hdr.isEscape {
+		t.Errorf("expected escape bit set, got %+v", hdr)
+	}
+	if !bytes.Equal(got, []byte{0x01, 0x02, 0x03, 0x04}) {
+		t.Errorf("payload mismatch")
+	}
+}
+
+func TestRecordReadErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		wire []byte
+		want string
+	}{
+		{"empty", []byte{}, ""},                                     // io.EOF
+		{"truncated 2-byte hdr", []byte{0x80}, ""},                  // unexpected EOF
+		{"zero length", []byte{0x80, 0x00}, "zero-length record"},
+		{"truncated body", []byte{0x80, 0x05, 0x01, 0x02}, ""},      // unexpected EOF
+		{"truncated 3-byte hdr", []byte{0x00, 0x05}, ""},            // unexpected EOF
+		{"pad bigger than length", []byte{0x00, 0x02, 0x05, 0x01, 0x02}, "pad length 5 exceeds record length 2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := readRecord(bytes.NewReader(tc.wire))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if tc.want != "" && !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecordWriteErrors(t *testing.T) {
+	if err := writeRecord(io.Discard, nil); err == nil {
+		t.Error("writeRecord(empty) returned nil error")
+	}
+	too := bytes.Repeat([]byte{0}, MaxRecordPayload+1)
+	if err := writeRecord(io.Discard, too); err == nil {
+		t.Error("writeRecord(oversized) returned nil error")
+	}
+}
+
+// errWriter rejects all writes — used to confirm we propagate I/O errors.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("io broken") }
+
+func TestRecordWritePropagatesIOError(t *testing.T) {
+	if err := writeRecord(errWriter{}, []byte{0x01}); err == nil {
+		t.Error("expected I/O error to propagate")
+	}
+}


### PR DESCRIPTION
Creates a new SSL 2.0 package for communicating with older endpoints.